### PR TITLE
allow use on multi-homed machines

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,12 @@
 ---
+- name: set boundary_address
+  when: boundary_iface is undefined
+  set_fact:
+    boundary_iface: "{{ ansible_default_ipv4.interface }}"
+
+- name: set boundary_address
+  set_fact:
+    boundary_address: "{{ hostvars[inventory_hostname]['ansible_'+boundary_iface]['ipv4']['address'] }}"
+
 - name: installing boundary
   include: boundary_install.yml

--- a/templates/boundary-controller.hcl.j2
+++ b/templates/boundary-controller.hcl.j2
@@ -12,7 +12,7 @@ controller {
 # API listener configuration block
 listener "tcp" {
   # Should be the address of the NIC that the controller server will be reached on
-  address = "{{ ansible_default_ipv4.address }}:9200"
+  address = "{{ boundary_address }}:9200"
   # The purpose of this listener block
   purpose = "api"
 
@@ -28,7 +28,7 @@ listener "tcp" {
 # Data-plane listener configuration block (used for worker coordination)
 listener "tcp" {
   # Should be the IP of the NIC that the worker will connect on
-  address = "{{ ansible_default_ipv4.address }}:9201"
+  address = "{{ boundary_address }}:9201"
   # The purpose of this listener
   purpose = "cluster"
 

--- a/templates/boundary-worker.hcl.j2
+++ b/templates/boundary-worker.hcl.j2
@@ -1,5 +1,5 @@
 listener "tcp" {
-  address = "{{ ansible_default_ipv4.address }}:9202"
+  address = "{{ boundary_address }}:9202"
   purpose = "proxy"
   tls_disable = {{ boundary_tls_disable | lower }}
 }


### PR DESCRIPTION
Fix for #5 
This introduces an optional variable for the network interface to use for Boundary, if not the default one.
(I define it in my inventory):

```ini
boundary_iface=enp0s8
```

This is used to compose the `boundary_address` variable.