### PR TITLE
setcap cap_ipc_lock=+ep

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,6 @@ boundary_checksum_file_url: "{{ boundary_url }}/{{ boundary_version }}/{{ bounda
 boundary_client_addr: '0.0.0.0'
 boundary_tls_disable: true
 boundary_cors_enabled: false
-boundary_disable_mlock: true
+boundary_disable_mlock: false
 
 boundary_kms_type: 'gcpckms'

--- a/tasks/boundary_install.yml
+++ b/tasks/boundary_install.yml
@@ -82,6 +82,18 @@
     group: '{{ boundary_group }}'
     mode: '0770'
 
+- name: check mlock capability
+  become: true
+  shell: "getcap {{ boundary_install_directory }}/boundary|grep cap_ipc_lock+ep"
+  changed_when: false  # read-only task
+  failed_when: false
+  register: mlock_capability
+
+- name: enable non root mlock capability
+  become: true
+  command: "setcap cap_ipc_lock=+ep {{ boundary_install_directory }}/boundary"
+  when: mlock_capability.rc|int == 1
+
 - name: templating out Boundary worker configuration
   block:
     - name: templating out boundary worker configuration file

--- a/templates/boundary-controller.systemd.j2
+++ b/templates/boundary-controller.systemd.j2
@@ -6,7 +6,7 @@ ExecStart={{ boundary_install_directory }}/boundary server -config {{ boundary_c
 User={{ boundary_user }}
 Group={{ boundary_group }}
 LimitMEMLOCK=infinity
-Capabilities=CAP_IPC_LOCK+ep
+AmbientCapabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 
 [Install]

--- a/templates/boundary-worker.systemd.j2
+++ b/templates/boundary-worker.systemd.j2
@@ -6,7 +6,7 @@ ExecStart={{ boundary_install_directory }}/boundary server -config {{ boundary_w
 User={{ boundary_user }}
 Group={{ boundary_group }}
 LimitMEMLOCK=infinity
-Capabilities=CAP_IPC_LOCK+ep
+AmbientCapabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 
 [Install]


### PR DESCRIPTION
give the Boundary executable the ability to use the mlock syscall without running as root.

https://www.boundaryproject.io/docs/configuration#disable_mlock

Fix for #7